### PR TITLE
OPENENGSB-3270 Sending of 'Object' instances with JSON, removes their subtype

### DIFF
--- a/bridge/src/main/java/org/openengsb/loom/java/util/JsonUtils.java
+++ b/bridge/src/main/java/org/openengsb/loom/java/util/JsonUtils.java
@@ -77,6 +77,10 @@ public final class JsonUtils {
         convertResult(message.getResult());
     }
 
+    public static <T> T convertArgument(Object object, Class<T> clazz) {
+        return MAPPER.convertValue(object, clazz);
+    }
+    
     private JsonUtils() {
     }
 }


### PR DESCRIPTION
- Added a helper method to JsonUtils (spares one to create and configure the ObjectMapper)

see http://issues.openengsb.org/jira/browse/OPENENGSB-3270#comment-16823
