### PR TITLE
OPENENGSB-3702: LoomJava fails in OSGi environment

### DIFF
--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -114,7 +114,6 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
     </dependency>
 
     <dependency>

--- a/bridge/src/main/java/org/openengsb/loom/java/ProxyConnectorFactory.java
+++ b/bridge/src/main/java/org/openengsb/loom/java/ProxyConnectorFactory.java
@@ -43,7 +43,7 @@ public class ProxyConnectorFactory {
     @SuppressWarnings("unchecked")
     public <T> T getRemoteProxy(Class<T> serviceType, final String serviceId) {
         RequestHandler requestHandler = remoteConfig.createOutgoingRequestHandler();
-        ClassLoader classLoader = getClass().getClassLoader();
+        ClassLoader classLoader = serviceType.getClassLoader();
         Class<?>[] interfaces = new Class<?>[]{ serviceType };
         RemoteServiceHandler remoteRequestHandler =
             new RemoteServiceHandler(serviceId, requestHandler, principal, credentials);
@@ -55,7 +55,7 @@ public class ProxyConnectorFactory {
     }
 
     public String createConnector(String domainType, Map<String, Object> properties)
-            throws ConnectorValidationFailedException {
+        throws ConnectorValidationFailedException {
         ConnectorDescription connectorDescription =
             new ConnectorDescription(domainType, "external-connector-proxy", new HashMap<String, String>(),
                 properties);


### PR DESCRIPTION
http://issues.openengsb.org/jira/browse/OPENENGSB-3702

Use classloader of the class being proxied, instead of loom classloader.
